### PR TITLE
Remove quite flag as it was added in newer versions

### DIFF
--- a/theme
+++ b/theme
@@ -2,4 +2,4 @@
 
 readonly DOCKER_IMAGE=northern/themekit:1.0
 
-docker pull -q "${DOCKER_IMAGE}" && docker run -v "$(pwd)":/build -w /build "${DOCKER_IMAGE}" "$@"
+docker pull "${DOCKER_IMAGE}" && docker run -v "$(pwd)":/build -w /build "${DOCKER_IMAGE}" "$@"


### PR DESCRIPTION
Goal: Allow older versions of docker